### PR TITLE
Issue #46

### DIFF
--- a/src/multiset.h
+++ b/src/multiset.h
@@ -147,6 +147,7 @@ public:
         for (int j = f[i]; j < f[i + 1]; j++) {
           for (int k = 0; k < v[j]; k++)
             part.push_back(obj->comp[c[j]]);
+          Rcpp::checkUserInterrupt();
         }
         partition.push_back(part);
       }


### PR DESCRIPTION
This PR closes #46 as suggested by @Enchufa2, including `Rcpp::checkUserInterrupt();` inside the multiset partitions generating loop to allow the user to stop if `max_order` is too big. The rest of the algorithm in `alg_non_linear` main bottleneck is inside `%in%` and this is interruptible. 